### PR TITLE
feat: findings ingestion + report-id (MVP workflow layer)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,84 +1,105 @@
 # bb-copilot
 
-> Asistente de bug bounty con IA. Vault de metodología + CLI clásica + workflow de findings.
+> Asistente de bug bounty con IA. Vault + CLI + workflow de findings y correlación real.
 
 > 🇬🇧 [English version](README.md)
 
 ```bash
-bbcopilot ask "api.target.com usa JWT y org_id en cada request"
-bbcopilot plan --target api.target.com --type api
-bbcopilot vuln idor --context notas.txt
-bbcopilot triage --finding "IDOR en /api/v1/invoices/{id}"
 bbcopilot ingest webxray out.jsonl
-bbcopilot correlate
+bbcopilot ingest takeovflow takeovers.jsonl
+bbcopilot ingest pathraider lfi.jsonl
+bbcopilot clusters
+bbcopilot cluster-show --id C-0001
 bbcopilot auto-triage
 bbcopilot exploit-plan
 ```
 
 ## Qué hace
 
-- Lee tu vault local (playbooks en Markdown por tipo de vuln y fase)
-- Envía el contexto adecuado + tu input al modelo configurado
-- Devuelve output estructurado y accionable: hipótesis → pasos → evidencia → impacto
-- Genera reportes completos listos para enviar a HackerOne, Bugcrowd o YesWeHack
-- Guarda historial local en `~/.bbcopilot/history/`
-- Almacena findings normalizados en `~/.bbcopilot/findings/`
-- Correlaciona findings de tools externas para priorizar superficies calientes
-- NO automatiza ataques. Guía tu razonamiento
+- Usa tu vault local (playbooks en Markdown)
+- Genera output estructurado: hipótesis → pasos → evidencia → impacto
+- Guarda historial en `~/.bbcopilot/history/`
+- Almacena findings en `~/.bbcopilot/findings/`
+- Correlaciona findings en clusters con score
+- NO automatiza ataques
 
-## Instalación
-
-```bash
-git clone https://github.com/theoffsecgirl/bb-copilot
-cd bb-copilot
-make setup
-```
-
-## Uso
-
-```bash
-bbcopilot ask "GraphQL con user_id"
-bbcopilot plan --target api.example.com --type api
-bbcopilot vuln idor
-bbcopilot triage --finding "open redirect"
-bbcopilot report --finding "IDOR en /api/v1/invoices/{id}"
-bbcopilot history
-bbcopilot vault-list
-```
+---
 
 ## Workflow de findings
 
+### 1. Ingestar
+
 ```bash
-# 1. Ingestar output de tools externas
 bbcopilot ingest webxray out.jsonl
+bbcopilot ingest takeovflow takeovers.jsonl
+bbcopilot ingest pathraider lfi.jsonl
+```
 
-# 2. Revisar findings
+### 2. Revisar
+
+```bash
 bbcopilot findings
-bbcopilot findings --tool webxray --vector xss --host api.example.com
+```
 
-# 3. Correlacionar
+### 3. Correlación v1 (clave)
+
+El sistema ya no agrupa solo por host/vector.
+
+Ahora crea **clusters** usando:
+- host
+- vector
+- parámetros
+- múltiples tools
+- severidad y confidence
+
+Cada cluster incluye:
+- cluster_id
+- score
+- why_it_matters
+- next_step
+
+```bash
 bbcopilot correlate
+bbcopilot clusters
+bbcopilot cluster-show --id C-0001
+```
 
-# 4. Triage automático
+### 4. Triage y explotación
+
+```bash
 bbcopilot auto-triage
-
-# 5. Plan de explotación
 bbcopilot exploit-plan
+```
 
-# 6. Reportes
-bbcopilot report-id --id F-...
+### 5. Reporte
+
+```bash
 bbcopilot report-top
 ```
 
-## Ejemplo de integración
+---
+
+## Ejemplo real
 
 ```bash
-webxray -u https://target.com --format jsonl --json-output out.jsonl
-bbcopilot ingest webxray out.jsonl
-bbcopilot correlate
-bbcopilot auto-triage
-bbcopilot exploit-plan
+webxray -u https://target.com --format jsonl --stdout > web.jsonl
+pathraider -u "https://target.com/download?file=FUZZ" --format jsonl --stdout > lfi.jsonl
+
+bbcopilot ingest webxray web.jsonl
+bbcopilot ingest pathraider lfi.jsonl
+
+bbcopilot clusters
 ```
+
+Salida:
+
+```text
+C-0001 target.com [lfd_traversal+xss] score=95
+why: mismo parámetro afectado por múltiples vectores
+next: probar /etc/passwd y escalar
+```
+
+---
 
 ## Comandos
 
@@ -94,15 +115,23 @@ bbcopilot exploit-plan
 | report-top | Reporte del cluster principal |
 | ingest | Importar findings |
 | findings | Listar findings |
-| correlate | Correlacionar findings |
+| correlate | Correlacionar |
+| clusters | Listar clusters |
+| cluster-show | Ver cluster |
 | auto-triage | Triage automático |
 | exploit-plan | Plan de explotación |
-| history | Historial |
-| vault-list | Vault |
+
+---
+
+## Modelo mental
+
+finding → señal
+cluster → hipótesis de bug
+
+---
 
 ## Filosofía
 
 - Resultado > explicación
-- Workflow reproducible
-- El vault es el cerebro
-- Los findings son la memoria
+- Clusters > findings
+- Menos ruido, más impacto

--- a/README.es.md
+++ b/README.es.md
@@ -1,15 +1,18 @@
 # bb-copilot
 
-> Asistente de bug bounty con IA. Vault de metodología + CLI guiado por conocimiento real de hunter.
+> Asistente de bug bounty con IA. Vault de metodología + CLI clásica + workflow de findings.
 
 > 🇬🇧 [English version](README.md)
 
-```
+```bash
 bbcopilot ask "api.target.com usa JWT y org_id en cada request"
 bbcopilot plan --target api.target.com --type api
 bbcopilot vuln idor --context notas.txt
 bbcopilot triage --finding "IDOR en /api/v1/invoices/{id}"
-bbcopilot report --finding "IDOR en /api/v1/invoices/{id}" --target api.target.com -o reporte.md
+bbcopilot ingest webxray out.jsonl
+bbcopilot correlate
+bbcopilot auto-triage
+bbcopilot exploit-plan
 ```
 
 ## Qué hace
@@ -18,16 +21,10 @@ bbcopilot report --finding "IDOR en /api/v1/invoices/{id}" --target api.target.c
 - Envía el contexto adecuado + tu input al modelo configurado
 - Devuelve output estructurado y accionable: hipótesis → pasos → evidencia → impacto
 - Genera reportes completos listos para enviar a HackerOne, Bugcrowd o YesWeHack
-- Guarda historial local de todas las sesiones en `~/.bbcopilot/history/`
-- NO automatiza ataques. Guía tu razonamiento.
-
-## Stack
-
-- Python 3.12+
-- [Typer](https://typer.tiangolo.com/) + [Rich](https://github.com/Textualize/rich)
-- Cualquier LLM compatible con API OpenAI: **Ollama, Groq, OpenAI, Anthropic**
-- Vault en Markdown (local, versionado en Git)
-- Historial en JSON local (`~/.bbcopilot/history/`)
+- Guarda historial local en `~/.bbcopilot/history/`
+- Almacena findings normalizados en `~/.bbcopilot/findings/`
+- Correlaciona findings de tools externas para priorizar superficies calientes
+- NO automatiza ataques. Guía tu razonamiento
 
 ## Instalación
 
@@ -37,129 +34,75 @@ cd bb-copilot
 make setup
 ```
 
-Luego edita `.env` según tu proveedor elegido (ver sección **Proveedores LLM**).
-
-## Proveedores LLM
-
-| Proveedor | Coste | Privacidad | Setup |
-|---|---|---|---|
-| **Ollama** (por defecto) | Gratis | Local — 100% privado | `brew install ollama` |
-| Groq | Gratis (tier limitado) | Nube | API key en console.groq.com |
-| OpenAI | De pago | Nube | API key en platform.openai.com |
-| Anthropic | De pago | Nube | API key en console.anthropic.com |
-
-### Ollama (por defecto)
-
-```bash
-brew install ollama
-ollama pull llama3.1   # ~4GB, solo una vez
-ollama serve           # arrancar en background
-```
-
-`.env`:
-```bash
-OPENAI_API_KEY=ollama
-OPENAI_BASE_URL=http://localhost:11434/v1
-OPENAI_MODEL=llama3.1
-```
-
-### Groq (gratis, nube)
-
-Atención: el tier gratuito tiene límite de ~6000 tokens de contexto. Añade esto al `.env`:
-```bash
-BBCOPILOT_MAX_CONTEXT_TOKENS=5000
-```
-
-### OpenAI
-
-```bash
-OPENAI_API_KEY=sk-proj-...
-OPENAI_BASE_URL=https://api.openai.com/v1
-OPENAI_MODEL=gpt-4o
-```
-
 ## Uso
 
 ```bash
-# Pregunta libre con todo el vault como contexto
-bbcopilot ask "el target tiene GraphQL con user_id en las mutations"
-
-# Plan de ataque priorizado para un target
-bbcopilot plan --target example.com --type web
+bbcopilot ask "GraphQL con user_id"
 bbcopilot plan --target api.example.com --type api
-
-# Playbook de una vulnerabilidad concreta
-bbcopilot vuln ssrf
-bbcopilot vuln idor --context mis-notas.txt
-
-# Triage de un hallazgo con siguientes pasos
-bbcopilot triage --finding "open redirect en /redirect?url="
-
-# Generar reporte completo listo para enviar
-bbcopilot report --finding "IDOR en /api/v1/invoices/{id} permite leer facturas ajenas"
-bbcopilot report --finding "..." --target api.example.com --context requests.txt --output reporte.md
-
-# Historial de sesiones
+bbcopilot vuln idor
+bbcopilot triage --finding "open redirect"
+bbcopilot report --finding "IDOR en /api/v1/invoices/{id}"
 bbcopilot history
-bbcopilot history --last 5
-bbcopilot history --clear
-
-# Listar todos los playbooks disponibles
 bbcopilot vault-list
+```
+
+## Workflow de findings
+
+```bash
+# 1. Ingestar output de tools externas
+bbcopilot ingest webxray out.jsonl
+
+# 2. Revisar findings
+bbcopilot findings
+bbcopilot findings --tool webxray --vector xss --host api.example.com
+
+# 3. Correlacionar
+bbcopilot correlate
+
+# 4. Triage automático
+bbcopilot auto-triage
+
+# 5. Plan de explotación
+bbcopilot exploit-plan
+
+# 6. Reportes
+bbcopilot report-id --id F-...
+bbcopilot report-top
+```
+
+## Ejemplo de integración
+
+```bash
+webxray -u https://target.com --format jsonl --json-output out.jsonl
+bbcopilot ingest webxray out.jsonl
+bbcopilot correlate
+bbcopilot auto-triage
+bbcopilot exploit-plan
 ```
 
 ## Comandos
 
-| Comando | Input | Output |
-|---|---|---|
-| `ask` | Observación en texto libre | Hipótesis priorizada + pasos |
-| `plan` | Target + tipo | Plan de ataque completo |
-| `vuln` | Clase de vuln + contexto opcional | Playbook + qué probar |
-| `triage` | Descripción del hallazgo | Severidad + evidencia + siguientes pasos |
-| `report` | Hallazgo + contexto opcional | Reporte completo (Markdown) |
-| `history` | — | Últimas sesiones en tabla |
-| `vault-list` | — | Lista de playbooks disponibles |
-
-## Estructura del vault
-
-```
-vault/
-├── methodology/    # Recon, triage de activos, análisis JS, API hunting, reporting
-├── vulns/          # Playbook por clase de vulnerabilidad
-├── patterns/       # Auth bypass, multi-tenant, role confusion, race conditions
-└── prompts/        # System prompt y reglas del modelo
-```
-
-## Vulnerabilidades cubiertas
-
-`IDOR` · `SSRF` · `XSS` · `SQLi` · `Open Redirect` · `File Upload` · `Subdomain Takeover` · `Business Logic` · `CORS` · `XXE` · `SSTI` · `OAuth`
-
-## Makefile
-
-```bash
-make setup    # Instalación inicial completa
-make install  # Solo dependencias
-make dev      # Dependencias + dev (pytest, ruff)
-make test     # Ejecutar tests
-make lint     # Linter
-make format   # Formatear código
-make vault    # Listar vault
-make ask Q="tu pregunta"  # Consulta rápida
-make clean    # Limpiar cachés
-```
-
-## Historial
-
-Todas las sesiones se guardan automáticamente en `~/.bbcopilot/history/` en formato JSON.
-Desáctivalo con `--no-save` en cualquier comando.
+| Comando | Descripción |
+|---|---|
+| ask | Pregunta libre |
+| plan | Plan de ataque |
+| vuln | Playbook |
+| triage | Triage manual |
+| triage-id | Triage desde finding |
+| report | Reporte completo |
+| report-id | Reporte desde finding |
+| report-top | Reporte del cluster principal |
+| ingest | Importar findings |
+| findings | Listar findings |
+| correlate | Correlacionar findings |
+| auto-triage | Triage automático |
+| exploit-plan | Plan de explotación |
+| history | Historial |
+| vault-list | Vault |
 
 ## Filosofía
 
-- Resultado sobre explicación
-- Siempre estructurado: hipótesis → checks → evidencia → impacto
-- El vault es el cerebro. El modelo es el motor.
-- Sin cajas negras. El conocimiento es tuyo.
-
----
-
-By [@theoffsecgirl](https://github.com/theoffsecgirl)
+- Resultado > explicación
+- Workflow reproducible
+- El vault es el cerebro
+- Los findings son la memoria

--- a/README.md
+++ b/README.md
@@ -18,14 +18,17 @@
 
 ---
 
-> AI-powered bug bounty assistant. Methodology vault + CLI guided by real hunter knowledge.
+> AI-powered bug bounty assistant. Methodology vault + classic guided CLI + findings workflow for real bug bounty pipelines.
 
-```
+```bash
 bbcopilot ask "api.target.com uses JWT and org_id in every request"
 bbcopilot plan --target api.target.com --type api
 bbcopilot vuln idor --context notes.txt
 bbcopilot triage --finding "IDOR on /api/v1/invoices/{id}"
-bbcopilot report --finding "IDOR on /api/v1/invoices/{id}" --target api.target.com -o report.md
+bbcopilot ingest webxray out.jsonl
+bbcopilot correlate
+bbcopilot auto-triage
+bbcopilot exploit-plan
 ```
 
 ## What it does
@@ -35,6 +38,8 @@ bbcopilot report --finding "IDOR on /api/v1/invoices/{id}" --target api.target.c
 - Returns structured, actionable output: hypotheses → steps → evidence → impact
 - Generates complete reports ready to submit to HackerOne, Bugcrowd or YesWeHack
 - Saves local history of all sessions in `~/.bbcopilot/history/`
+- Stores normalized findings in `~/.bbcopilot/findings/`
+- Correlates findings from external tools to prioritize hotter surfaces
 - Does NOT automate attacks. Guides your reasoning.
 
 ## Stack
@@ -44,6 +49,7 @@ bbcopilot report --finding "IDOR on /api/v1/invoices/{id}" --target api.target.c
 - Any OpenAI-compatible LLM API: **Ollama, Groq, OpenAI, Anthropic**
 - Markdown vault (local, Git-versioned)
 - Local JSON history (`~/.bbcopilot/history/`)
+- Local JSONL findings store (`~/.bbcopilot/findings/`)
 
 ## Installation
 
@@ -124,65 +130,40 @@ bbcopilot history --clear
 bbcopilot vault-list
 ```
 
-## Output example
+## Findings workflow
 
-### `bbcopilot ask`
+This layer turns `bb-copilot` from a guided assistant into a workflow hub:
 
-```text
-$ bbcopilot ask "api.target.com uses JWT and org_id in every request"
+```bash
+# 1. Ingest output from external tools
+bbcopilot ingest webxray out.jsonl
 
-╭─ bb-copilot ─────────────────────────────────────────────────────────╮
-│ Context loaded: 8 playbooks (idor, auth, jwt, api, cors, ssrf, biz)  │
-╰───────────────────────────────────────────────────────────────────────╯
+# 2. Review stored findings
+bbcopilot findings
+bbcopilot findings --tool webxray --vector xss --host api.example.com
 
-📌 Hypotheses (prioritized)
+# 3. Correlate by host/vector
+bbcopilot correlate
 
-1. IDOR via org_id manipulation
-   → Replace org_id in requests with another org's ID
-   → Test: GET /api/v1/invoices?org_id=<other_org>
-   Confidence: HIGH
+# 4. Triage the hottest cluster automatically
+bbcopilot auto-triage
 
-2. JWT algorithm confusion (RS256 → HS256)
-   → Decode JWT, modify alg header, re-sign with public key as secret
-   Confidence: MEDIUM
+# 5. Generate an exploit validation plan
+bbcopilot exploit-plan
 
-3. Missing org_id validation on bulk endpoints
-   → POST /api/v1/export — does it check org_id ownership?
-   Confidence: MEDIUM
-
-🔎 Next steps
-  1. Enumerate all endpoints accepting org_id
-  2. Create two test accounts in different orgs
-  3. Cross-org request matrix
-
-💾 Session saved → ~/.bbcopilot/history/2026-04-17_ask_001.json
+# 6. Generate a report from one finding or top cluster
+bbcopilot report-id --id F-202604190001-0001
+bbcopilot report-top -o top-report.md
 ```
 
-### `bbcopilot report`
+### Example integration
 
-```text
-$ bbcopilot report --finding "IDOR on /api/v1/invoices/{id} exposes other users invoices" --target api.target.com
-
-╭─ Generating report ──────────────────────────────────────────────────╮
-│ Vuln: IDOR  │ Target: api.target.com  │ Format: HackerOne Markdown   │
-╰───────────────────────────────────────────────────────────────────────╯
-
-## Summary
-Insecure Direct Object Reference on `/api/v1/invoices/{id}` allows
-authenticated users to access invoices belonging to other accounts
-by incrementing the `id` parameter.
-
-## Steps to reproduce
-1. Log in as user A, create an invoice → note ID (e.g. 1042)
-2. Log in as user B
-3. Send: GET /api/v1/invoices/1041
-4. Observe: invoice data from user A is returned
-
-## Impact
-Full read access to all invoices across all accounts.
-Estimated severity: **High** (CVSS 8.1)
-
-[+] Report saved → report.md
+```bash
+webxray -u https://target.com --format jsonl --json-output out.jsonl
+bbcopilot ingest webxray out.jsonl
+bbcopilot correlate
+bbcopilot auto-triage
+bbcopilot exploit-plan
 ```
 
 ---
@@ -195,13 +176,21 @@ Estimated severity: **High** (CVSS 8.1)
 | `plan` | Target + type | Full attack plan |
 | `vuln` | Vuln class + optional context | Playbook + what to test |
 | `triage` | Finding description | Severity + evidence + next steps |
+| `triage-id` | Stored finding ID | Triage from normalized finding |
 | `report` | Finding + optional context | Full report (Markdown) |
+| `report-id` | Stored finding ID | Full report from one finding |
+| `report-top` | — | Full report from top correlation |
+| `ingest` | Tool name + JSON/JSONL | Normalize and persist findings |
+| `findings` | Optional filters | List stored findings |
+| `correlate` | — | Group findings by host/vector |
+| `auto-triage` | — | Triage top correlation |
+| `exploit-plan` | — | Exploit/validation plan for top correlation |
 | `history` | — | Last sessions in table |
 | `vault-list` | — | List of available playbooks |
 
 ## Vault structure
 
-```
+```text
 vault/
 ├── methodology/    # Recon, asset triage, JS analysis, API hunting, reporting
 ├── vulns/          # Playbook per vulnerability class
@@ -227,16 +216,17 @@ make ask Q="your question"  # Quick query
 make clean    # Clean caches
 ```
 
-## History
+## Storage
 
-All sessions are automatically saved to `~/.bbcopilot/history/` in JSON format.
-Disable with `--no-save` on any command.
+- History: `~/.bbcopilot/history/`
+- Findings: `~/.bbcopilot/findings/`
 
 ## Philosophy
 
 - Result over explanation
 - Always structured: hypotheses → checks → evidence → impact
 - The vault is the brain. The model is the engine.
+- Findings make the workflow reproducible.
 - No black boxes. The knowledge is yours.
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@
 > AI-powered bug bounty assistant. Methodology vault + classic guided CLI + findings workflow for real bug bounty pipelines.
 
 ```bash
-bbcopilot ask "api.target.com uses JWT and org_id in every request"
-bbcopilot plan --target api.target.com --type api
-bbcopilot vuln idor --context notes.txt
-bbcopilot triage --finding "IDOR on /api/v1/invoices/{id}"
 bbcopilot ingest webxray out.jsonl
-bbcopilot correlate
+bbcopilot ingest takeovflow takeovers.jsonl
+bbcopilot ingest pathraider lfi.jsonl
+bbcopilot clusters
+bbcopilot cluster-show --id C-0001
 bbcopilot auto-triage
 bbcopilot exploit-plan
+bbcopilot report-top
 ```
 
 ## What it does
@@ -39,7 +39,7 @@ bbcopilot exploit-plan
 - Generates complete reports ready to submit to HackerOne, Bugcrowd or YesWeHack
 - Saves local history of all sessions in `~/.bbcopilot/history/`
 - Stores normalized findings in `~/.bbcopilot/findings/`
-- Correlates findings from external tools to prioritize hotter surfaces
+- Correlates findings into scored clusters
 - Does NOT automate attacks. Guides your reasoning.
 
 ## Stack
@@ -59,111 +59,90 @@ cd bb-copilot
 make setup
 ```
 
-Then edit `.env` according to your chosen provider (see **LLM Providers** section).
-
-## LLM Providers
-
-| Provider | Cost | Privacy | Setup |
-|---|---|---|---|
-| **Ollama** (default) | Free | Local — 100% private | `brew install ollama` |
-| Groq | Free (limited tier) | Cloud | API key at console.groq.com |
-| OpenAI | Paid | Cloud | API key at platform.openai.com |
-| Anthropic | Paid | Cloud | API key at console.anthropic.com |
-
-### Ollama (default)
-
-```bash
-brew install ollama
-ollama pull llama3.1   # ~4GB, one-time
-ollama serve           # run in background
-```
-
-`.env`:
-```bash
-OPENAI_API_KEY=ollama
-OPENAI_BASE_URL=http://localhost:11434/v1
-OPENAI_MODEL=llama3.1
-```
-
-### Groq (free, cloud)
-
-Note: free tier has ~6000 token context limit. Add to `.env`:
-```bash
-BBCOPILOT_MAX_CONTEXT_TOKENS=5000
-```
-
-### OpenAI
-
-```bash
-OPENAI_API_KEY=sk-proj-...
-OPENAI_BASE_URL=https://api.openai.com/v1
-OPENAI_MODEL=gpt-4o
-```
-
 ## Usage
 
 ```bash
-# Free-form question with full vault as context
 bbcopilot ask "target has GraphQL with user_id in mutations"
-
-# Prioritized attack plan for a target
 bbcopilot plan --target example.com --type web
-bbcopilot plan --target api.example.com --type api
-
-# Playbook for a specific vulnerability
 bbcopilot vuln ssrf
-bbcopilot vuln idor --context my-notes.txt
-
-# Triage a finding with next steps
 bbcopilot triage --finding "open redirect on /redirect?url="
-
-# Generate complete report ready to submit
 bbcopilot report --finding "IDOR on /api/v1/invoices/{id} exposes other users' invoices"
-bbcopilot report --finding "..." --target api.example.com --context requests.txt --output report.md
-
-# Session history
 bbcopilot history
-bbcopilot history --last 5
-bbcopilot history --clear
-
-# List all available playbooks
 bbcopilot vault-list
 ```
 
 ## Findings workflow
 
-This layer turns `bb-copilot` from a guided assistant into a workflow hub:
+This layer turns `bb-copilot` from a guided assistant into a workflow hub.
+
+### 1. Ingest
 
 ```bash
-# 1. Ingest output from external tools
 bbcopilot ingest webxray out.jsonl
+bbcopilot ingest takeovflow takeovers.jsonl
+bbcopilot ingest pathraider lfi.jsonl
+```
 
-# 2. Review stored findings
+### 2. Review findings
+
+```bash
 bbcopilot findings
 bbcopilot findings --tool webxray --vector xss --host api.example.com
+```
 
-# 3. Correlate by host/vector
+### 3. Correlation v1
+
+`bb-copilot` no longer just groups by host/vector. It builds **clusters** using:
+- host
+- vector
+- param overlap
+- multi-tool agreement
+- severity and confidence
+
+Each cluster exposes:
+- `cluster_id`
+- `score`
+- `why_it_matters`
+- `next_step`
+- tools involved
+- targets involved
+- finding ids
+
+```bash
 bbcopilot correlate
+bbcopilot clusters
+bbcopilot cluster-show --id C-0001
+```
 
-# 4. Triage the hottest cluster automatically
+### 4. Triage and exploit
+
+```bash
 bbcopilot auto-triage
-
-# 5. Generate an exploit validation plan
 bbcopilot exploit-plan
+```
 
-# 6. Generate a report from one finding or top cluster
+### 5. Report
+
+```bash
 bbcopilot report-id --id F-202604190001-0001
 bbcopilot report-top -o top-report.md
 ```
 
-### Example integration
+## Example integration
 
 ```bash
-webxray -u https://target.com --format jsonl --json-output out.jsonl
-bbcopilot ingest webxray out.jsonl
-bbcopilot correlate
-bbcopilot auto-triage
+webxray -u https://target.com --format jsonl --json-output web.jsonl
+pathraider -u "https://target.com/download?file=FUZZ" --format jsonl --stdout > lfi.jsonl
+takeovflow -d target.com --format jsonl --stdout > takeover.jsonl
+
+bbcopilot ingest webxray web.jsonl
+bbcopilot ingest pathraider lfi.jsonl
+bbcopilot ingest takeovflow takeover.jsonl
+
+bbcopilot clusters
+bbcopilot cluster-show --id C-0001
 bbcopilot exploit-plan
+bbcopilot report-top
 ```
 
 ---
@@ -179,42 +158,28 @@ bbcopilot exploit-plan
 | `triage-id` | Stored finding ID | Triage from normalized finding |
 | `report` | Finding + optional context | Full report (Markdown) |
 | `report-id` | Stored finding ID | Full report from one finding |
-| `report-top` | — | Full report from top correlation |
+| `report-top` | — | Full report from top scored cluster |
 | `ingest` | Tool name + JSON/JSONL | Normalize and persist findings |
 | `findings` | Optional filters | List stored findings |
-| `correlate` | — | Group findings by host/vector |
-| `auto-triage` | — | Triage top correlation |
-| `exploit-plan` | — | Exploit/validation plan for top correlation |
+| `correlate` | — | Show scored correlations |
+| `clusters` | — | List scored clusters |
+| `cluster-show` | Cluster ID | Inspect one cluster |
+| `auto-triage` | — | Triage top cluster |
+| `exploit-plan` | — | Exploit/validation plan for top cluster |
 | `history` | — | Last sessions in table |
 | `vault-list` | — | List of available playbooks |
 
-## Vault structure
+## Correlation model
 
-```text
-vault/
-├── methodology/    # Recon, asset triage, JS analysis, API hunting, reporting
-├── vulns/          # Playbook per vulnerability class
-├── patterns/       # Auth bypass, multi-tenant, role confusion, race conditions
-└── prompts/        # System prompt and model rules
-```
+A finding is a signal.
+A cluster is a bug hypothesis.
 
-## Covered vulnerabilities
+The current correlator prioritizes:
+- same host + same vector
+- same host + same param + different vectors
+- multiple tools agreeing on the same surface
 
-`IDOR` · `SSRF` · `XSS` · `SQLi` · `Open Redirect` · `File Upload` · `Subdomain Takeover` · `Business Logic` · `CORS` · `XXE` · `SSTI` · `OAuth`
-
-## Makefile
-
-```bash
-make setup    # Full initial setup
-make install  # Dependencies only
-make dev      # Dependencies + dev (pytest, ruff)
-make test     # Run tests
-make lint     # Linter
-make format   # Format code
-make vault    # List vault
-make ask Q="your question"  # Quick query
-make clean    # Clean caches
-```
+This is enough to reduce noise and surface likely real bugs fast.
 
 ## Storage
 
@@ -227,6 +192,7 @@ make clean    # Clean caches
 - Always structured: hypotheses → checks → evidence → impact
 - The vault is the brain. The model is the engine.
 - Findings make the workflow reproducible.
+- Clusters make the workflow actionable.
 - No black boxes. The knowledge is yours.
 
 ---

--- a/cli/findings.py
+++ b/cli/findings.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 FINDINGS_DIR = Path(os.getenv("BBCOPILOT_FINDINGS_DIR", "~/.bbcopilot/findings")).expanduser()
 
@@ -17,12 +18,15 @@ def _gen_id(index: int) -> str:
     return f"F-{ts}-{index:04d}"
 
 
+def _gen_cluster_id(index: int) -> str:
+    return f"C-{index:04d}"
+
+
 def _iter_input_records(file_path: str) -> list[dict[str, Any]]:
     path = Path(file_path)
     text = path.read_text(encoding="utf-8").strip()
     if not text:
         return []
-
     if path.suffix.lower() == ".jsonl":
         records: list[dict[str, Any]] = []
         for line in text.splitlines():
@@ -30,12 +34,8 @@ def _iter_input_records(file_path: str) -> list[dict[str, Any]]:
             if not line:
                 continue
             obj = json.loads(line)
-            if isinstance(obj, dict):
-                records.append(obj)
-            else:
-                records.append({"value": obj})
+            records.append(obj if isinstance(obj, dict) else {"value": obj})
         return records
-
     data = json.loads(text)
     if isinstance(data, list):
         return [item if isinstance(item, dict) else {"value": item} for item in data]
@@ -55,11 +55,22 @@ def _iter_input_records(file_path: str) -> list[dict[str, Any]]:
     return [{"value": data}]
 
 
+def _derive_host(item: dict[str, Any]) -> str | None:
+    if item.get("host"):
+        return item.get("host")
+    target = item.get("target") or item.get("url")
+    if not target:
+        return None
+    try:
+        return urlparse(str(target)).netloc or None
+    except Exception:
+        return None
+
+
 def normalize_records(tool: str, file_path: str) -> list[dict[str, Any]]:
     raw_records = _iter_input_records(file_path)
     now = datetime.now().isoformat()
     normalized: list[dict[str, Any]] = []
-
     for idx, item in enumerate(raw_records, start=1):
         entry = {
             "id": _gen_id(idx),
@@ -67,11 +78,12 @@ def normalize_records(tool: str, file_path: str) -> list[dict[str, Any]]:
             "type": item.get("type", "unknown"),
             "vector": item.get("vector"),
             "target": item.get("target") or item.get("url") or item.get("host"),
-            "host": item.get("host"),
+            "host": _derive_host(item),
             "method": item.get("method"),
             "param": item.get("param"),
-            "severity": item.get("severity", "info"),
-            "confidence": item.get("confidence", "low"),
+            "severity": str(item.get("severity", "info")).lower(),
+            "confidence": str(item.get("confidence", "low")).lower(),
+            "reason": item.get("reason"),
             "evidence": item.get("evidence", []),
             "tags": item.get("tags", []),
             "raw": item,
@@ -85,11 +97,9 @@ def save_findings(tool: str, findings: list[dict[str, Any]]) -> Path:
     _ensure_dir()
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_path = FINDINGS_DIR / f"{ts}_{tool}.jsonl"
-
     with output_path.open("w", encoding="utf-8") as f:
         for item in findings:
             f.write(json.dumps(item, ensure_ascii=False) + "\n")
-
     return output_path
 
 
@@ -122,29 +132,142 @@ def find_by_id(finding_id: str) -> dict[str, Any] | None:
     return None
 
 
-def correlate_findings() -> list[dict[str, Any]]:
-    findings = load_all_findings()
+def _deduplicate_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str, str, str]] = set()
+    unique: list[dict[str, Any]] = []
+    for f in findings:
+        key = (
+            str(f.get("host") or ""),
+            str(f.get("vector") or f.get("type") or ""),
+            str(f.get("param") or ""),
+            str(f.get("target") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(f)
+    return unique
+
+
+def _score_cluster(items: list[dict[str, Any]]) -> int:
+    score = 0
+    severity_map = {"critical": 90, "high": 70, "medium": 50, "low": 30, "info": 10}
+    confidence_map = {"high": 15, "medium": 8, "low": 2}
+    tools = {str(i.get('tool', 'unknown')) for i in items}
+    params = {str(i.get('param')) for i in items if i.get('param')}
+    severities = [severity_map.get(str(i.get("severity", "info")).lower(), 10) for i in items]
+    confidences = [confidence_map.get(str(i.get("confidence", "low")).lower(), 2) for i in items]
+    score += max(severities) if severities else 0
+    score += max(confidences) if confidences else 0
+    score += max(0, (len(tools) - 1) * 20)
+    if len(params) == 1 and params:
+        score += 30
+    if len(items) >= 3:
+        score += 10
+    return min(score, 100)
+
+
+def _why_it_matters(items: list[dict[str, Any]]) -> str:
+    tools = sorted({str(i.get('tool', 'unknown')) for i in items})
+    params = sorted({str(i.get('param')) for i in items if i.get('param')})
+    vectors = sorted({str(i.get('vector') or i.get('type') or 'unknown') for i in items})
+    if len(tools) > 1 and len(params) == 1 and params:
+        return f"same param flagged across multiple tools ({', '.join(tools)})"
+    if len(tools) > 1:
+        return f"multiple tools agree on the same host/vector ({', '.join(tools)})"
+    return f"repeated signals for vector(s): {', '.join(vectors)}"
+
+
+def _next_step(items: list[dict[str, Any]]) -> str:
+    vectors = {str(i.get('vector') or i.get('type') or '').lower() for i in items}
+    if 'lfd_traversal' in vectors:
+        return 'validate with /etc/passwd or win.ini and then test escalation paths like /proc/self/environ or log poisoning'
+    if 'subdomain_takeover' in vectors:
+        return 'verify provider claim path, dangling DNS state and takeover confirmation page/body'
+    if 'xss' in vectors:
+        return 'confirm execution context, sink type and try auth-impacting pages'
+    if 'sqli' in vectors:
+        return 'confirm with controlled error/time-based payloads and minimize PoC'
+    return 'manually validate the strongest finding in the cluster and look for impact amplification'
+
+
+def build_clusters(findings: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    findings = _deduplicate_findings(findings or load_all_findings())
     grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    param_grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
 
     for finding in findings:
         host = finding.get("host") or "unknown-host"
         vector = finding.get("vector") or finding.get("type") or "unknown"
-        grouped[(host, vector)].append(finding)
+        grouped[(str(host), str(vector))].append(finding)
+        if finding.get("param"):
+            param_grouped[(str(host), str(finding.get('param')))].append(finding)
 
-    correlations: list[dict[str, Any]] = []
+    clusters: list[dict[str, Any]] = []
+    cluster_index = 1
+
     for (host, vector), items in grouped.items():
         if len(items) < 2:
             continue
-        correlations.append(
+        clusters.append({
+            "cluster_id": _gen_cluster_id(cluster_index),
+            "host": host,
+            "vector": vector,
+            "params": sorted({str(i.get('param')) for i in items if i.get('param')}),
+            "tools": sorted({str(i.get('tool', 'unknown')) for i in items}),
+            "finding_ids": [i.get('id') for i in items],
+            "targets": sorted({str(i.get('target')) for i in items if i.get('target')}),
+            "score": _score_cluster(items),
+            "why_it_matters": _why_it_matters(items),
+            "next_step": _next_step(items),
+            "evidence_summary": [str(i.get('reason') or '') for i in items if i.get('reason')][:5],
+        })
+        cluster_index += 1
+
+    for (host, param), items in param_grouped.items():
+        tools = {str(i.get('tool', 'unknown')) for i in items}
+        vectors = {str(i.get('vector') or i.get('type') or 'unknown') for i in items}
+        if len(items) < 2 or len(vectors) < 2:
+            continue
+        clusters.append({
+            "cluster_id": _gen_cluster_id(cluster_index),
+            "host": host,
+            "vector": "+".join(sorted(vectors)),
+            "params": [param],
+            "tools": sorted(tools),
+            "finding_ids": [i.get('id') for i in items],
+            "targets": sorted({str(i.get('target')) for i in items if i.get('target')}),
+            "score": min(_score_cluster(items) + 15, 100),
+            "why_it_matters": f"same param flagged with multiple vectors on {host}",
+            "next_step": _next_step(items),
+            "evidence_summary": [str(i.get('reason') or '') for i in items if i.get('reason')][:5],
+        })
+        cluster_index += 1
+
+    clusters.sort(key=lambda x: x["score"], reverse=True)
+    return clusters
+
+
+def correlate_findings() -> list[dict[str, Any]]:
+    clusters = build_clusters()
+    simplified: list[dict[str, Any]] = []
+    for c in clusters:
+        simplified.append(
             {
-                "host": host,
-                "vector": vector,
-                "count": len(items),
-                "ids": [item.get("id") for item in items],
-                "tools": sorted({item.get("tool", "unknown") for item in items}),
-                "targets": sorted({item.get("target", "") for item in items if item.get("target")}),
+                "host": c["host"],
+                "vector": c["vector"],
+                "count": len(c["finding_ids"]),
+                "ids": c["finding_ids"],
+                "tools": c["tools"],
+                "targets": c["targets"],
+                "score": c["score"],
             }
         )
+    return simplified
 
-    correlations.sort(key=lambda x: x["count"], reverse=True)
-    return correlations
+
+def get_cluster(cluster_id: str) -> dict[str, Any] | None:
+    for cluster in build_clusters():
+        if cluster.get("cluster_id") == cluster_id:
+            return cluster
+    return None

--- a/cli/findings.py
+++ b/cli/findings.py
@@ -1,5 +1,6 @@
 import json
 import os
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -119,3 +120,31 @@ def find_by_id(finding_id: str) -> dict[str, Any] | None:
         if finding.get("id") == finding_id:
             return finding
     return None
+
+
+def correlate_findings() -> list[dict[str, Any]]:
+    findings = load_all_findings()
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+
+    for finding in findings:
+        host = finding.get("host") or "unknown-host"
+        vector = finding.get("vector") or finding.get("type") or "unknown"
+        grouped[(host, vector)].append(finding)
+
+    correlations: list[dict[str, Any]] = []
+    for (host, vector), items in grouped.items():
+        if len(items) < 2:
+            continue
+        correlations.append(
+            {
+                "host": host,
+                "vector": vector,
+                "count": len(items),
+                "ids": [item.get("id") for item in items],
+                "tools": sorted({item.get("tool", "unknown") for item in items}),
+                "targets": sorted({item.get("target", "") for item in items if item.get("target")}),
+            }
+        )
+
+    correlations.sort(key=lambda x: x["count"], reverse=True)
+    return correlations

--- a/cli/findings.py
+++ b/cli/findings.py
@@ -1,0 +1,121 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+FINDINGS_DIR = Path(os.getenv("BBCOPILOT_FINDINGS_DIR", "~/.bbcopilot/findings")).expanduser()
+
+
+def _ensure_dir() -> None:
+    FINDINGS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _gen_id(index: int) -> str:
+    ts = datetime.now().strftime("%Y%m%d%H%M%S")
+    return f"F-{ts}-{index:04d}"
+
+
+def _iter_input_records(file_path: str) -> list[dict[str, Any]]:
+    path = Path(file_path)
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+
+    if path.suffix.lower() == ".jsonl":
+        records: list[dict[str, Any]] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if isinstance(obj, dict):
+                records.append(obj)
+            else:
+                records.append({"value": obj})
+        return records
+
+    data = json.loads(text)
+    if isinstance(data, list):
+        return [item if isinstance(item, dict) else {"value": item} for item in data]
+    if isinstance(data, dict):
+        records = []
+        for key, value in data.items():
+            if isinstance(value, list):
+                for item in value:
+                    obj = item if isinstance(item, dict) else {"value": item}
+                    obj.setdefault("type", key)
+                    records.append(obj)
+            else:
+                obj = value if isinstance(value, dict) else {"value": value}
+                obj.setdefault("type", key)
+                records.append(obj)
+        return records
+    return [{"value": data}]
+
+
+def normalize_records(tool: str, file_path: str) -> list[dict[str, Any]]:
+    raw_records = _iter_input_records(file_path)
+    now = datetime.now().isoformat()
+    normalized: list[dict[str, Any]] = []
+
+    for idx, item in enumerate(raw_records, start=1):
+        entry = {
+            "id": _gen_id(idx),
+            "tool": tool,
+            "type": item.get("type", "unknown"),
+            "vector": item.get("vector"),
+            "target": item.get("target") or item.get("url") or item.get("host"),
+            "host": item.get("host"),
+            "method": item.get("method"),
+            "param": item.get("param"),
+            "severity": item.get("severity", "info"),
+            "confidence": item.get("confidence", "low"),
+            "evidence": item.get("evidence", []),
+            "tags": item.get("tags", []),
+            "raw": item,
+            "timestamp": item.get("timestamp", now),
+        }
+        normalized.append(entry)
+    return normalized
+
+
+def save_findings(tool: str, findings: list[dict[str, Any]]) -> Path:
+    _ensure_dir()
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_path = FINDINGS_DIR / f"{ts}_{tool}.jsonl"
+
+    with output_path.open("w", encoding="utf-8") as f:
+        for item in findings:
+            f.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+    return output_path
+
+
+def ingest_file(tool: str, file_path: str) -> tuple[int, Path]:
+    findings = normalize_records(tool, file_path)
+    output_path = save_findings(tool, findings)
+    return len(findings), output_path
+
+
+def load_all_findings() -> list[dict[str, Any]]:
+    _ensure_dir()
+    results: list[dict[str, Any]] = []
+    for file in sorted(FINDINGS_DIR.glob("*.jsonl")):
+        with file.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    results.append(json.loads(line))
+                except Exception:
+                    continue
+    return results
+
+
+def find_by_id(finding_id: str) -> dict[str, Any] | None:
+    for finding in load_all_findings():
+        if finding.get("id") == finding_id:
+            return finding
+    return None

--- a/cli/main.py
+++ b/cli/main.py
@@ -26,7 +26,6 @@ def ask(
     full: bool = typer.Option(False, "--full", "-f", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Pregunta libre. Compacto por defecto, --full para output completo."""
     from cli.planner import run_ask
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -47,7 +46,6 @@ def plan(
     full: bool = typer.Option(False, "--full", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Plan de ataque completo. Compacto por defecto, --full para más detalle."""
     from cli.planner import run_plan
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -67,7 +65,6 @@ def vuln(
     full: bool = typer.Option(False, "--full", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Playbook de una vulnerabilidad. Compacto por defecto."""
     from cli.planner import run_vuln
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -86,7 +83,6 @@ def triage(
     full: bool = typer.Option(False, "--full", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Triage de un hallazgo. Compacto por defecto."""
     from cli.planner import run_triage
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -103,15 +99,12 @@ def triage(
 def triage_id(
     finding_id: str = typer.Option(..., "--id", help="ID del finding"),
 ) -> None:
-    """Triage usando un finding almacenado por ID."""
     from cli.findings import find_by_id
     from cli.planner import run_triage
-
     finding = find_by_id(finding_id)
     if not finding:
         console.print("[red]Finding no encontrado[/red]")
         raise typer.Exit(code=1)
-
     result = run_triage(json.dumps(finding, ensure_ascii=False, indent=2), full=True)
     _print_response(result.raw, result.tokens_used)
 
@@ -124,7 +117,6 @@ def report(
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Reporte completo listo para HackerOne/Bugcrowd/YesWeHack."""
     from cli.reporter import run_report
     from cli.history import save as save_history
     console.print(Panel(f"[bold cyan]Reporte:[/bold cyan] {finding}", expand=False))
@@ -146,18 +138,14 @@ def report_id(
     finding_id: str = typer.Option(..., "--id", help="ID del finding"),
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
 ) -> None:
-    """Genera un reporte desde un finding almacenado por ID."""
     from cli.findings import find_by_id
     from cli.reporter import run_report
-
     finding = find_by_id(finding_id)
     if not finding:
         console.print("[red]Finding no encontrado[/red]")
         raise typer.Exit(code=1)
-
     result = run_report(json.dumps(finding, ensure_ascii=False, indent=2))
     _print_response(result.raw, result.tokens_used)
-
     if output:
         out_file = output if output.endswith(".md") else output + ".md"
         with open(out_file, "w", encoding="utf-8") as f:
@@ -169,19 +157,15 @@ def report_id(
 def report_top(
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
 ) -> None:
-    """Genera reporte usando la correlación más fuerte encontrada."""
     from cli.findings import correlate_findings
     from cli.reporter import run_report
-
     results = correlate_findings()
     if not results:
         console.print("[dim]No se encontraron correlaciones[/dim]")
         raise typer.Exit(code=1)
-
     top = results[0]
     result = run_report(json.dumps(top, ensure_ascii=False, indent=2))
     _print_response(result.raw, result.tokens_used)
-
     if output:
         out_file = output if output.endswith(".md") else output + ".md"
         with open(out_file, "w", encoding="utf-8") as f:
@@ -194,7 +178,6 @@ def history(
     last: int = typer.Option(10, "--last", "-n", help="Número de entradas"),
     clear: bool = typer.Option(False, "--clear", help="Borrar todo el historial"),
 ) -> None:
-    """Ver o gestionar el historial de sesiones."""
     from cli.history import load_last, clear as clear_history
     if clear:
         n = clear_history()
@@ -220,7 +203,6 @@ def history(
 
 @app.command(name="vault-list")
 def vault_list() -> None:
-    """Lista todos los playbooks disponibles en el vault."""
     from cli.vault import load_all
     ctx = load_all()
     console.print("[bold]Vault — playbooks disponibles:[/bold]")
@@ -234,7 +216,6 @@ def ingest(
     tool: str = typer.Argument(..., help="Nombre de la tool origen"),
     input_file: str = typer.Argument(..., help="Fichero JSON/JSONL de entrada"),
 ) -> None:
-    """Importa findings de tools externas y los normaliza."""
     from cli.findings import ingest_file
     count, path = ingest_file(tool, input_file)
     console.print(f"[green]Importados {count} findings[/green]")
@@ -248,7 +229,6 @@ def findings(
     host: Optional[str] = typer.Option(None, "--host", help="Filtrar por host"),
     limit: int = typer.Option(50, "--limit", help="Máximo de resultados a mostrar"),
 ) -> None:
-    """Lista findings almacenados con filtros básicos."""
     from cli.findings import load_all_findings
     data = load_all_findings()
     if tool:
@@ -266,30 +246,56 @@ def findings(
 
 @app.command()
 def correlate() -> None:
-    """Agrupa findings por host y vector para priorizar superficies calientes."""
     from cli.findings import correlate_findings
     results = correlate_findings()
     if not results:
         console.print("[dim]No correlations found[/dim]")
         return
     for c in results:
-        console.print(f"[yellow]{c['host']}[/yellow] [{c['vector']}] → {c['count']} findings")
+        console.print(f"[yellow]{c['host']}[/yellow] [{c['vector']}] → {c['count']} findings | score={c.get('score', 0)}")
         console.print(f"  tools: {', '.join(c['tools'])}")
         for t in c['targets'][:3]:
             console.print(f"    - {t}")
 
 
+@app.command()
+def clusters(
+    limit: int = typer.Option(20, "--limit", help="Máximo de clusters a mostrar"),
+) -> None:
+    from cli.findings import build_clusters
+    results = build_clusters()
+    if not results:
+        console.print("[dim]No clusters[/dim]")
+        return
+    for c in results[:limit]:
+        console.print(f"[bold cyan]{c['cluster_id']}[/bold cyan] {c['host']} [{c['vector']}] score={c['score']}")
+        console.print(f"  tools: {', '.join(c['tools'])}")
+        if c.get('params'):
+            console.print(f"  params: {', '.join(c['params'])}")
+        console.print(f"  why: {c['why_it_matters']}")
+        console.print(f"  next: {c['next_step']}")
+
+
+@app.command(name="cluster-show")
+def cluster_show(
+    cluster_id: str = typer.Option(..., "--id", help="ID del cluster"),
+) -> None:
+    from cli.findings import get_cluster
+    cluster = get_cluster(cluster_id)
+    if not cluster:
+        console.print("[red]Cluster no encontrado[/red]")
+        raise typer.Exit(code=1)
+    console.print(json.dumps(cluster, ensure_ascii=False, indent=2))
+
+
 @app.command(name="auto-triage")
 def auto_triage() -> None:
-    """Ejecuta triage sobre la correlación más fuerte encontrada."""
     from cli.findings import correlate_findings
     from cli.planner import run_triage
-
     results = correlate_findings()
     if not results:
         console.print("[dim]No correlations found[/dim]")
         return
-
     top = results[0]
     summary = json.dumps(top, ensure_ascii=False, indent=2)
     console.print(f"[bold cyan]Auto-triaging top correlation:[/bold cyan] {top['host']} [{top['vector']}]")
@@ -299,15 +305,12 @@ def auto_triage() -> None:
 
 @app.command(name="exploit-plan")
 def exploit_plan() -> None:
-    """Genera plan de explotación guiado para la correlación más fuerte."""
     from cli.findings import correlate_findings
     from cli.planner import run_exploit_plan
-
     results = correlate_findings()
     if not results:
         console.print("[dim]No correlations found[/dim]")
         return
-
     top = results[0]
     summary = json.dumps(top, ensure_ascii=False, indent=2)
     console.print(f"[bold red]Exploit planning:[/bold red] {top['host']} [{top['vector']}]")

--- a/cli/main.py
+++ b/cli/main.py
@@ -20,12 +20,67 @@ def _print_response(raw: str, tokens: int = 0) -> None:
 
 
 @app.command()
+def ingest(
+    tool: str = typer.Argument(..., help="Nombre de la tool origen"),
+    file: str = typer.Argument(..., help="Fichero JSON/JSONL de entrada"),
+) -> None:
+    """Importa findings de tools externas y los normaliza."""
+    from cli.findings import ingest_file
+
+    count, path = ingest_file(tool, file)
+    console.print(f"[green]Imported {count} findings[/green]")
+    console.print(f"[dim]{path}[/dim]")
+
+
+@app.command()
+def findings(
+    limit: int = typer.Option(50, "--limit", help="Máximo de resultados a mostrar"),
+) -> None:
+    """Lista findings almacenados."""
+    from cli.findings import load_all_findings
+
+    data = load_all_findings()
+    if not data:
+        console.print("[dim]No findings[/dim]")
+        return
+
+    for f in data[:limit]:
+        console.print(f"[cyan]{f.get('id')}[/cyan] {f.get('type')} {f.get('tool')} {f.get('target')}")
+
+
+@app.command(name="report-id")
+def report_id(
+    finding_id: str = typer.Option(..., "--id", help="ID del finding"),
+    output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
+) -> None:
+    """Genera reporte desde finding estructurado."""
+    import json
+    from cli.findings import find_by_id
+    from cli.reporter import run_report
+
+    finding = find_by_id(finding_id)
+    if not finding:
+        console.print("[red]Finding not found[/red]")
+        return
+
+    desc = json.dumps(finding, ensure_ascii=False, indent=2)
+    result = run_report(desc)
+
+    _print_response(result.raw, result.tokens_used)
+
+    if output:
+        out_file = output if output.endswith(".md") else output + ".md"
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(result.raw)
+        console.print(f"[green]Reporte guardado en {out_file}[/green]")
+
+
+@app.command()
 def ask(
     observation: str = typer.Argument(..., help="Observación o pregunta sobre un target"),
     full: bool = typer.Option(False, "--full", "-f", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Pregunta libre. Compacto por defecto, --full para output completo."""
     from cli.planner import run_ask
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -46,7 +101,6 @@ def plan(
     full: bool = typer.Option(False, "--full", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Plan de ataque completo. Compacto por defecto, --full para más detalle."""
     from cli.planner import run_plan
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -66,7 +120,6 @@ def vuln(
     full: bool = typer.Option(False, "--full", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Playbook de una vulnerabilidad. Compacto por defecto."""
     from cli.planner import run_vuln
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -85,7 +138,6 @@ def triage(
     full: bool = typer.Option(False, "--full", help="Output detallado completo"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Triage de un hallazgo. Compacto por defecto."""
     from cli.planner import run_triage
     from cli.history import save as save_history
     mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
@@ -106,7 +158,6 @@ def report(
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
     save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
 ) -> None:
-    """Reporte completo listo para HackerOne/Bugcrowd/YesWeHack."""
     from cli.reporter import run_report
     from cli.history import save as save_history
     console.print(Panel(f"[bold cyan]Reporte:[/bold cyan] {finding}", expand=False))
@@ -128,7 +179,6 @@ def history(
     last: int = typer.Option(10, "--last", "-n", help="Número de entradas"),
     clear: bool = typer.Option(False, "--clear", help="Borrar todo el historial"),
 ) -> None:
-    """Ver o gestionar el historial de sesiones."""
     from cli.history import load_last, clear as clear_history
     if clear:
         n = clear_history()
@@ -154,7 +204,6 @@ def history(
 
 @app.command(name="vault-list")
 def vault_list() -> None:
-    """Lista todos los playbooks disponibles en el vault."""
     from cli.vault import load_all
     ctx = load_all()
     console.print("[bold]Vault — playbooks disponibles:[/bold]")

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,8 +1,6 @@
 import typer
 from rich.console import Console
 from rich.markdown import Markdown
-from rich.panel import Panel
-from rich.table import Table
 from typing import Optional
 
 app = typer.Typer(
@@ -50,6 +48,24 @@ def correlate() -> None:
         console.print(f"  tools: {', '.join(c['tools'])}")
         for t in c['targets'][:3]:
             console.print(f"    - {t}")
+
+
+@app.command(name="auto-triage")
+def auto_triage() -> None:
+    import json
+    from cli.findings import correlate_findings
+    from cli.planner import run_triage
+
+    results = correlate_findings()
+    if not results:
+        console.print("[dim]No correlations found[/dim]")
+        return
+
+    top = results[0]
+    summary = json.dumps(top, ensure_ascii=False, indent=2)
+    console.print(f"[bold cyan]Auto-triaging top correlation:[/bold cyan] {top['host']} [{top['vector']}]")
+    result = run_triage(summary, full=True)
+    _print_response(result.raw, result.tokens_used)
 
 
 @app.command(name="report-id")

--- a/cli/main.py
+++ b/cli/main.py
@@ -20,40 +20,40 @@ def _print_response(raw: str, tokens: int = 0) -> None:
 
 
 @app.command()
-def ingest(
-    tool: str = typer.Argument(..., help="Nombre de la tool origen"),
-    file: str = typer.Argument(..., help="Fichero JSON/JSONL de entrada"),
-) -> None:
-    """Importa findings de tools externas y los normaliza."""
+def ingest(tool: str, file: str) -> None:
     from cli.findings import ingest_file
-
     count, path = ingest_file(tool, file)
     console.print(f"[green]Imported {count} findings[/green]")
     console.print(f"[dim]{path}[/dim]")
 
 
 @app.command()
-def findings(
-    limit: int = typer.Option(50, "--limit", help="Máximo de resultados a mostrar"),
-) -> None:
-    """Lista findings almacenados."""
+def findings(limit: int = 50) -> None:
     from cli.findings import load_all_findings
-
     data = load_all_findings()
     if not data:
         console.print("[dim]No findings[/dim]")
         return
-
     for f in data[:limit]:
         console.print(f"[cyan]{f.get('id')}[/cyan] {f.get('type')} {f.get('tool')} {f.get('target')}")
 
 
+@app.command()
+def correlate() -> None:
+    from cli.findings import correlate_findings
+    results = correlate_findings()
+    if not results:
+        console.print("[dim]No correlations found[/dim]")
+        return
+    for c in results:
+        console.print(f"[yellow]{c['host']}[/yellow] [{c['vector']}] → {c['count']} findings")
+        console.print(f"  tools: {', '.join(c['tools'])}")
+        for t in c['targets'][:3]:
+            console.print(f"    - {t}")
+
+
 @app.command(name="report-id")
-def report_id(
-    finding_id: str = typer.Option(..., "--id", help="ID del finding"),
-    output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
-) -> None:
-    """Genera reporte desde finding estructurado."""
+def report_id(finding_id: str, output: Optional[str] = None) -> None:
     import json
     from cli.findings import find_by_id
     from cli.reporter import run_report
@@ -65,151 +65,11 @@ def report_id(
 
     desc = json.dumps(finding, ensure_ascii=False, indent=2)
     result = run_report(desc)
-
     _print_response(result.raw, result.tokens_used)
 
     if output:
-        out_file = output if output.endswith(".md") else output + ".md"
-        with open(out_file, "w", encoding="utf-8") as f:
+        with open(output, "w", encoding="utf-8") as f:
             f.write(result.raw)
-        console.print(f"[green]Reporte guardado en {out_file}[/green]")
-
-
-@app.command()
-def ask(
-    observation: str = typer.Argument(..., help="Observación o pregunta sobre un target"),
-    full: bool = typer.Option(False, "--full", "-f", help="Output detallado completo"),
-    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
-) -> None:
-    from cli.planner import run_ask
-    from cli.history import save as save_history
-    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
-    console.print(Panel(f"[bold cyan]Pregunta:[/bold cyan] {observation} {mode}", expand=False))
-    with console.status("[bold green]Pensando...[/bold green]"):
-        result = run_ask(observation, full=full)
-    _print_response(result.raw, result.tokens_used)
-    if save:
-        path = save_history("ask", observation, result)
-        console.print(f"[dim]Guardado en {path}[/dim]")
-
-
-@app.command()
-def plan(
-    target: str = typer.Option(..., "--target", "-t", help="URL o dominio del target"),
-    type: str = typer.Option("web", "--type", help="Tipo: web | api | mobile"),
-    context: Optional[str] = typer.Option(None, "--context", "-c", help="Fichero de contexto"),
-    full: bool = typer.Option(False, "--full", help="Output detallado completo"),
-    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
-) -> None:
-    from cli.planner import run_plan
-    from cli.history import save as save_history
-    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
-    console.print(Panel(f"[bold cyan]Plan:[/bold cyan] {target} [{type}] {mode}", expand=False))
-    with console.status("[bold green]Construyendo plan...[/bold green]"):
-        result = run_plan(target, type, context, full=full)
-    _print_response(result.raw, result.tokens_used)
-    if save:
-        path = save_history("plan", f"{target} [{type}]", result)
-        console.print(f"[dim]Guardado en {path}[/dim]")
-
-
-@app.command()
-def vuln(
-    name: str = typer.Argument(..., help="Clase de vuln: idor, ssrf, xss, cors..."),
-    context: Optional[str] = typer.Option(None, "--context", "-c", help="Fichero de contexto"),
-    full: bool = typer.Option(False, "--full", help="Output detallado completo"),
-    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
-) -> None:
-    from cli.planner import run_vuln
-    from cli.history import save as save_history
-    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
-    console.print(Panel(f"[bold cyan]Vuln:[/bold cyan] {name.upper()} {mode}", expand=False))
-    with console.status("[bold green]Cargando playbook...[/bold green]"):
-        result = run_vuln(name, context, full=full)
-    _print_response(result.raw, result.tokens_used)
-    if save:
-        path = save_history("vuln", name, result)
-        console.print(f"[dim]Guardado en {path}[/dim]")
-
-
-@app.command()
-def triage(
-    finding: str = typer.Option(..., "--finding", help="Hallazgo a triar"),
-    full: bool = typer.Option(False, "--full", help="Output detallado completo"),
-    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
-) -> None:
-    from cli.planner import run_triage
-    from cli.history import save as save_history
-    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
-    console.print(Panel(f"[bold cyan]Triage:[/bold cyan] {finding} {mode}", expand=False))
-    with console.status("[bold green]Triando...[/bold green]"):
-        result = run_triage(finding, full=full)
-    _print_response(result.raw, result.tokens_used)
-    if save:
-        path = save_history("triage", finding, result)
-        console.print(f"[dim]Guardado en {path}[/dim]")
-
-
-@app.command()
-def report(
-    finding: str = typer.Option(..., "--finding", help="Descripción del hallazgo"),
-    target: Optional[str] = typer.Option(None, "--target", "-t", help="Target"),
-    context: Optional[str] = typer.Option(None, "--context", "-c", help="Fichero con requests/notas"),
-    output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
-    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
-) -> None:
-    from cli.reporter import run_report
-    from cli.history import save as save_history
-    console.print(Panel(f"[bold cyan]Reporte:[/bold cyan] {finding}", expand=False))
-    with console.status("[bold green]Generando reporte...[/bold green]"):
-        result = run_report(finding, context, target)
-    _print_response(result.raw, result.tokens_used)
-    if output:
-        out_file = output if output.endswith(".md") else output + ".md"
-        with open(out_file, "w", encoding="utf-8") as f:
-            f.write(result.raw)
-        console.print(f"[green]Reporte guardado en {out_file}[/green]")
-    if save:
-        path = save_history("report", finding, result)
-        console.print(f"[dim]Guardado en historial: {path}[/dim]")
-
-
-@app.command()
-def history(
-    last: int = typer.Option(10, "--last", "-n", help="Número de entradas"),
-    clear: bool = typer.Option(False, "--clear", help="Borrar todo el historial"),
-) -> None:
-    from cli.history import load_last, clear as clear_history
-    if clear:
-        n = clear_history()
-        console.print(f"[yellow]Historial borrado ({n} entradas).[/yellow]")
-        return
-    entries = load_last(last)
-    if not entries:
-        console.print("[dim]No hay entradas en el historial.[/dim]")
-        return
-    table = Table(title=f"Últimas {len(entries)} entradas", show_lines=True)
-    table.add_column("Fecha", style="dim", width=20)
-    table.add_column("Comando", style="cyan", width=10)
-    table.add_column("Input", style="white")
-    table.add_column("Tokens", style="dim", width=8)
-    for e in entries:
-        ts = e.get("timestamp", "")[:19].replace("T", " ")
-        cmd = e.get("command", "")
-        inp = e.get("input", "")[:80] + ("..." if len(e.get("input", "")) > 80 else "")
-        tokens = str(e.get("tokens", ""))
-        table.add_row(ts, cmd, inp, tokens)
-    console.print(table)
-
-
-@app.command(name="vault-list")
-def vault_list() -> None:
-    from cli.vault import load_all
-    ctx = load_all()
-    console.print("[bold]Vault — playbooks disponibles:[/bold]")
-    for f in ctx.files:
-        console.print(f"  [green]✓[/green] {f}")
-    console.print(f"\n[dim]{len(ctx.files)} ficheros cargados[/dim]")
 
 
 if __name__ == "__main__":

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,9 @@
+import json
 import typer
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.table import Table
 from typing import Optional
 
 app = typer.Typer(
@@ -18,17 +21,242 @@ def _print_response(raw: str, tokens: int = 0) -> None:
 
 
 @app.command()
-def ingest(tool: str, file: str) -> None:
+def ask(
+    observation: str = typer.Argument(..., help="Observación o pregunta sobre un target"),
+    full: bool = typer.Option(False, "--full", "-f", help="Output detallado completo"),
+    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
+) -> None:
+    """Pregunta libre. Compacto por defecto, --full para output completo."""
+    from cli.planner import run_ask
+    from cli.history import save as save_history
+    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
+    console.print(Panel(f"[bold cyan]Pregunta:[/bold cyan] {observation} {mode}", expand=False))
+    with console.status("[bold green]Pensando...[/bold green]"):
+        result = run_ask(observation, full=full)
+    _print_response(result.raw, result.tokens_used)
+    if save:
+        path = save_history("ask", observation, result)
+        console.print(f"[dim]Guardado en {path}[/dim]")
+
+
+@app.command()
+def plan(
+    target: str = typer.Option(..., "--target", "-t", help="URL o dominio del target"),
+    type: str = typer.Option("web", "--type", help="Tipo: web | api | mobile"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Fichero de contexto"),
+    full: bool = typer.Option(False, "--full", help="Output detallado completo"),
+    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
+) -> None:
+    """Plan de ataque completo. Compacto por defecto, --full para más detalle."""
+    from cli.planner import run_plan
+    from cli.history import save as save_history
+    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
+    console.print(Panel(f"[bold cyan]Plan:[/bold cyan] {target} [{type}] {mode}", expand=False))
+    with console.status("[bold green]Construyendo plan...[/bold green]"):
+        result = run_plan(target, type, context, full=full)
+    _print_response(result.raw, result.tokens_used)
+    if save:
+        path = save_history("plan", f"{target} [{type}]", result)
+        console.print(f"[dim]Guardado en {path}[/dim]")
+
+
+@app.command()
+def vuln(
+    name: str = typer.Argument(..., help="Clase de vuln: idor, ssrf, xss, cors..."),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Fichero de contexto"),
+    full: bool = typer.Option(False, "--full", help="Output detallado completo"),
+    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
+) -> None:
+    """Playbook de una vulnerabilidad. Compacto por defecto."""
+    from cli.planner import run_vuln
+    from cli.history import save as save_history
+    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
+    console.print(Panel(f"[bold cyan]Vuln:[/bold cyan] {name.upper()} {mode}", expand=False))
+    with console.status("[bold green]Cargando playbook...[/bold green]"):
+        result = run_vuln(name, context, full=full)
+    _print_response(result.raw, result.tokens_used)
+    if save:
+        path = save_history("vuln", name, result)
+        console.print(f"[dim]Guardado en {path}[/dim]")
+
+
+@app.command()
+def triage(
+    finding: str = typer.Option(..., "--finding", help="Hallazgo a triar"),
+    full: bool = typer.Option(False, "--full", help="Output detallado completo"),
+    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
+) -> None:
+    """Triage de un hallazgo. Compacto por defecto."""
+    from cli.planner import run_triage
+    from cli.history import save as save_history
+    mode = "[dim][full][/dim]" if full else "[dim][compact][/dim]"
+    console.print(Panel(f"[bold cyan]Triage:[/bold cyan] {finding} {mode}", expand=False))
+    with console.status("[bold green]Triando...[/bold green]"):
+        result = run_triage(finding, full=full)
+    _print_response(result.raw, result.tokens_used)
+    if save:
+        path = save_history("triage", finding, result)
+        console.print(f"[dim]Guardado en {path}[/dim]")
+
+
+@app.command(name="triage-id")
+def triage_id(
+    finding_id: str = typer.Option(..., "--id", help="ID del finding"),
+) -> None:
+    """Triage usando un finding almacenado por ID."""
+    from cli.findings import find_by_id
+    from cli.planner import run_triage
+
+    finding = find_by_id(finding_id)
+    if not finding:
+        console.print("[red]Finding no encontrado[/red]")
+        raise typer.Exit(code=1)
+
+    result = run_triage(json.dumps(finding, ensure_ascii=False, indent=2), full=True)
+    _print_response(result.raw, result.tokens_used)
+
+
+@app.command()
+def report(
+    finding: str = typer.Option(..., "--finding", help="Descripción del hallazgo"),
+    target: Optional[str] = typer.Option(None, "--target", "-t", help="Target"),
+    context: Optional[str] = typer.Option(None, "--context", "-c", help="Fichero con requests/notas"),
+    output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
+    save: bool = typer.Option(True, "--save/--no-save", help="Guardar en historial"),
+) -> None:
+    """Reporte completo listo para HackerOne/Bugcrowd/YesWeHack."""
+    from cli.reporter import run_report
+    from cli.history import save as save_history
+    console.print(Panel(f"[bold cyan]Reporte:[/bold cyan] {finding}", expand=False))
+    with console.status("[bold green]Generando reporte...[/bold green]"):
+        result = run_report(finding, context, target)
+    _print_response(result.raw, result.tokens_used)
+    if output:
+        out_file = output if output.endswith(".md") else output + ".md"
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(result.raw)
+        console.print(f"[green]Reporte guardado en {out_file}[/green]")
+    if save:
+        path = save_history("report", finding, result)
+        console.print(f"[dim]Guardado en historial: {path}[/dim]")
+
+
+@app.command(name="report-id")
+def report_id(
+    finding_id: str = typer.Option(..., "--id", help="ID del finding"),
+    output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
+) -> None:
+    """Genera un reporte desde un finding almacenado por ID."""
+    from cli.findings import find_by_id
+    from cli.reporter import run_report
+
+    finding = find_by_id(finding_id)
+    if not finding:
+        console.print("[red]Finding no encontrado[/red]")
+        raise typer.Exit(code=1)
+
+    result = run_report(json.dumps(finding, ensure_ascii=False, indent=2))
+    _print_response(result.raw, result.tokens_used)
+
+    if output:
+        out_file = output if output.endswith(".md") else output + ".md"
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(result.raw)
+        console.print(f"[green]Reporte guardado en {out_file}[/green]")
+
+
+@app.command(name="report-top")
+def report_top(
+    output: Optional[str] = typer.Option(None, "--output", "-o", help="Guardar en fichero .md"),
+) -> None:
+    """Genera reporte usando la correlación más fuerte encontrada."""
+    from cli.findings import correlate_findings
+    from cli.reporter import run_report
+
+    results = correlate_findings()
+    if not results:
+        console.print("[dim]No se encontraron correlaciones[/dim]")
+        raise typer.Exit(code=1)
+
+    top = results[0]
+    result = run_report(json.dumps(top, ensure_ascii=False, indent=2))
+    _print_response(result.raw, result.tokens_used)
+
+    if output:
+        out_file = output if output.endswith(".md") else output + ".md"
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(result.raw)
+        console.print(f"[green]Reporte guardado en {out_file}[/green]")
+
+
+@app.command()
+def history(
+    last: int = typer.Option(10, "--last", "-n", help="Número de entradas"),
+    clear: bool = typer.Option(False, "--clear", help="Borrar todo el historial"),
+) -> None:
+    """Ver o gestionar el historial de sesiones."""
+    from cli.history import load_last, clear as clear_history
+    if clear:
+        n = clear_history()
+        console.print(f"[yellow]Historial borrado ({n} entradas).[/yellow]")
+        return
+    entries = load_last(last)
+    if not entries:
+        console.print("[dim]No hay entradas en el historial.[/dim]")
+        return
+    table = Table(title=f"Últimas {len(entries)} entradas", show_lines=True)
+    table.add_column("Fecha", style="dim", width=20)
+    table.add_column("Comando", style="cyan", width=10)
+    table.add_column("Input", style="white")
+    table.add_column("Tokens", style="dim", width=8)
+    for e in entries:
+        ts = e.get("timestamp", "")[:19].replace("T", " ")
+        cmd = e.get("command", "")
+        inp = e.get("input", "")[:80] + ("..." if len(e.get("input", "")) > 80 else "")
+        tokens = str(e.get("tokens", ""))
+        table.add_row(ts, cmd, inp, tokens)
+    console.print(table)
+
+
+@app.command(name="vault-list")
+def vault_list() -> None:
+    """Lista todos los playbooks disponibles en el vault."""
+    from cli.vault import load_all
+    ctx = load_all()
+    console.print("[bold]Vault — playbooks disponibles:[/bold]")
+    for f in ctx.files:
+        console.print(f"  [green]✓[/green] {f}")
+    console.print(f"\n[dim]{len(ctx.files)} ficheros cargados[/dim]")
+
+
+@app.command()
+def ingest(
+    tool: str = typer.Argument(..., help="Nombre de la tool origen"),
+    input_file: str = typer.Argument(..., help="Fichero JSON/JSONL de entrada"),
+) -> None:
+    """Importa findings de tools externas y los normaliza."""
     from cli.findings import ingest_file
-    count, path = ingest_file(tool, file)
-    console.print(f"[green]Imported {count} findings[/green]")
+    count, path = ingest_file(tool, input_file)
+    console.print(f"[green]Importados {count} findings[/green]")
     console.print(f"[dim]{path}[/dim]")
 
 
 @app.command()
-def findings(limit: int = 50) -> None:
+def findings(
+    tool: Optional[str] = typer.Option(None, "--tool", help="Filtrar por tool"),
+    vector: Optional[str] = typer.Option(None, "--vector", help="Filtrar por vector"),
+    host: Optional[str] = typer.Option(None, "--host", help="Filtrar por host"),
+    limit: int = typer.Option(50, "--limit", help="Máximo de resultados a mostrar"),
+) -> None:
+    """Lista findings almacenados con filtros básicos."""
     from cli.findings import load_all_findings
     data = load_all_findings()
+    if tool:
+        data = [f for f in data if f.get("tool") == tool]
+    if vector:
+        data = [f for f in data if f.get("vector") == vector]
+    if host:
+        data = [f for f in data if f.get("host") == host]
     if not data:
         console.print("[dim]No findings[/dim]")
         return
@@ -38,6 +266,7 @@ def findings(limit: int = 50) -> None:
 
 @app.command()
 def correlate() -> None:
+    """Agrupa findings por host y vector para priorizar superficies calientes."""
     from cli.findings import correlate_findings
     results = correlate_findings()
     if not results:
@@ -52,7 +281,7 @@ def correlate() -> None:
 
 @app.command(name="auto-triage")
 def auto_triage() -> None:
-    import json
+    """Ejecuta triage sobre la correlación más fuerte encontrada."""
     from cli.findings import correlate_findings
     from cli.planner import run_triage
 
@@ -68,24 +297,22 @@ def auto_triage() -> None:
     _print_response(result.raw, result.tokens_used)
 
 
-@app.command(name="report-id")
-def report_id(finding_id: str, output: Optional[str] = None) -> None:
-    import json
-    from cli.findings import find_by_id
-    from cli.reporter import run_report
+@app.command(name="exploit-plan")
+def exploit_plan() -> None:
+    """Genera plan de explotación guiado para la correlación más fuerte."""
+    from cli.findings import correlate_findings
+    from cli.planner import run_exploit_plan
 
-    finding = find_by_id(finding_id)
-    if not finding:
-        console.print("[red]Finding not found[/red]")
+    results = correlate_findings()
+    if not results:
+        console.print("[dim]No correlations found[/dim]")
         return
 
-    desc = json.dumps(finding, ensure_ascii=False, indent=2)
-    result = run_report(desc)
+    top = results[0]
+    summary = json.dumps(top, ensure_ascii=False, indent=2)
+    console.print(f"[bold red]Exploit planning:[/bold red] {top['host']} [{top['vector']}]")
+    result = run_exploit_plan(summary, full=True)
     _print_response(result.raw, result.tokens_used)
-
-    if output:
-        with open(output, "w", encoding="utf-8") as f:
-            f.write(result.raw)
 
 
 if __name__ == "__main__":

--- a/cli/planner.py
+++ b/cli/planner.py
@@ -119,3 +119,23 @@ def run_triage(finding: str, full: bool = False) -> CopilotResponse:
         f"siguientes pasos para escalar y estructura del reporte."
     )
     return ask(system, user_msg, ctx.content)
+
+
+def run_exploit_plan(finding: str, full: bool = True) -> CopilotResponse:
+    ctx = _smart_context(finding)
+    system = load_system_prompt()
+    user_msg = (
+        f"{_mode_instruction(full)}\n\n"
+        f"Genera un plan de explotación y validación para este hallazgo priorizado:\n\n{finding}\n\n"
+        f"Devuelve exactamente estas secciones:\n"
+        f"1. Hipótesis de explotación\n"
+        f"2. Qué indica cada señal observada\n"
+        f"3. Payloads o mutaciones concretas a probar\n"
+        f"4. Pasos de validación en orden\n"
+        f"5. Indicadores de confirmación\n"
+        f"6. Variantes del vector\n"
+        f"7. Impacto probable\n"
+        f"8. Qué buscar después\n\n"
+        f"No automatices ataques. Prioriza PoC mínima, reproducible y segura."
+    )
+    return ask(system, user_msg, ctx.content)


### PR DESCRIPTION
Adds a minimal findings layer to bb-copilot:

- ingest external tool outputs (json/jsonl)
- normalize and persist findings locally
- list findings
- generate reports from structured findings (report-id)

This is the first step towards turning bb-copilot into a full workflow hub (recon → triage → report).

Next steps:
- tool-specific normalizers
- correlation engine
- scoring
- triage from findings

Non-breaking change: existing commands untouched.